### PR TITLE
Bugfixes: Keine Ersetzung in Buttons, Wortgrenzen, Doppelmarkierung & Eigenmarkierung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Changelog
 
+### 08.05.2026
+
+- Fix: Buttons werden standardmäßig nicht mehr mit Glossarbegriffen markiert.
+- Fix: Wortgrenzen-Erkennung berücksichtigt nun Umlaute und Bindestriche korrekt — Begriffe wie „RoS" matchen nicht mehr in „Büros", und „E-Mail" wird in „E-Mail-Adresse" nicht mehr als Treffer gewertet.
+- Fix: Bei direkter Nachbarschaft von Abkürzung und Langform (oder beliebigen Alt-Begriffen) wird nur noch eine Variante pro Begriffsgruppe markiert.
+- Feature: Container mit dem Attribut `data-multiglossar-self="<pid>"` werden vom Parser als Render-Bereich des jeweiligen Eintrags erkannt — der eigene Begriff (inkl. Alt-Begriffe) wird in diesem Bereich nicht markiert, andere Glossar-Querverweise bleiben aktiv. Das mitgelieferte Beispiel-Listenansicht-Modul nutzt dieses Attribut bereits.
+
 ### 09.04.2026 Version 3.0.0 beta 2
 
 - Feature: Konfigurierbare HTML5 data-Attribute für z.b. tinymce-Editoren (Definition und Beschreibung) hinzugefügt.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Das AddOn erkennt ob meherere Domains in YRewrite hinterlegt wurden. Es ist dahe
 ### Alternative Begriffe
 Zusätzlich zum Hauptbegriff können alternative Begriffe angegeben werden. Diese werden bei der Ersetzung wie zusätzliche Einträge mit gleicher Definition behandelt. Wird beispielsweise "Schach" als Glossarbegriff definiert und "Schachspiel" als alternativer Begriff und es kommen beide Begriffe auf der Seite vor, so werden auch beide Begriffe markiert.
 
+Pro Stelle wird allerdings nur eine Variante markiert — wenn z. B. eine Abkürzung und ihre Langform direkt nebeneinander stehen ("ABC (Alpha Beta Cell)"), wird nur der erste Treffer als Glossar-Link ausgegeben.
+
+### Eigene Begriffe im Glossar-Eintrag nicht doppelt markieren
+Wer auf einer Seite einen Glossar-Eintrag selbst rendert (z. B. in der Listenansicht eines Glossars), kann den Wrapper-Container mit `data-multiglossar-self="<pid>"` versehen — dabei ist `<pid>` die `pid` des aktuell gerenderten Eintrags aus der Tabelle `rex_multiglossar`. Das AddOn überspringt dann genau diesen Eintrag bei der automatischen Markierung — Querverweise auf andere Glossarbegriffe innerhalb des Eintrags bleiben aktiv. Das mitgelieferte Beispiel-Modul für die Listenansicht nutzt das Attribut bereits.
+
 ### Administration
 - Der gewünschte WYSIWYG-Editor kann per CSS-Class durch den Administrator definiert werden. 
 - Es können Start- und End-Tags definiert werden
@@ -49,7 +54,7 @@ _Für weitere Informationen kontaktieren Sie Ihren Webmaster_
 
 In der aktuellen Version findet die Ersetzung zum Teil über DOMDocument statt, das heißt der gesamte Ausgabecode wird geparst, um die Ersetzung genauer zu steuern.
 
-Standardmäßig werden Glossarbegriffe in den Tags h1 bis h6, a und figcaption nicht markiert. Zusätzlich können Textteile mit <!--exclude-->...<!--endexclude--> von der Ersetzung ausgeschlossen werden.
+Standardmäßig werden Glossarbegriffe in den Tags `h1` bis `h6`, `a`, `button`, `figcaption`, `script`, `style`, `svg` und `dfn` nicht markiert. Zusätzlich können Textteile mit <!--exclude-->...<!--endexclude--> von der Ersetzung ausgeschlossen werden.
 
 In den Einstellungen können *zusätzliche Tags* angegeben werden, in denen Glossarbegriffe nicht markiert werden. Beispielsweise ul,aside,nav usw.
 

--- a/data/glossar_listenansicht_modulausgabe.php
+++ b/data/glossar_listenansicht_modulausgabe.php
@@ -17,6 +17,7 @@ $counter = $bcounter = 1;
 if (count($sql)) {
   foreach($sql as $row) {
     $id = $row->getValue("id");
+    $pid = $row->getValue("pid");
     $begriff = $row->getValue("term");
     $char = strtoupper(substr($begriff,0,1)); // Erster character
     $beschreibung = $row->getValue("definition");
@@ -28,7 +29,7 @@ if (count($sql)) {
     } else {$character  = "";}
 
     $out .= $character .'
-      <div class="panel panel-default">
+      <div class="panel panel-default" data-multiglossar-self="'.$pid.'">
         <div class="panel-heading">
           <a data-toggle="collapse" data-parent="#accordionREX_SLICE_ID" href="#collapse'.$counter.'">'.$begriff.'</a>
         </div>

--- a/lib/glossar/multiglossar.php
+++ b/lib/glossar/multiglossar.php
@@ -15,6 +15,7 @@ class Parser
     private $locked_classes = [];
     private $article_complete;
     private $glossar_id;
+    private $self_pid_stack = [];
     private $header = '<?xml encoding="UTF-8"><html><head><meta content="text/html; charset=utf-8" http-equiv="Content-Type"></head><body>';
     private $footer = '</body></html>';
     private $url_key = 'gloss_id';
@@ -141,7 +142,7 @@ class Parser
         // gesperrte Tags initialisieren
         // kann sowohl Elemente als auch css Klassen enthalten
 
-        $ignoreTags = array_merge(['a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'figcaption', 'exclude', 'script', 'style', 'svg', 'dfn'], explode(',', \rex_config::get('multiglossar', 'glossar_ignoretags') ?: ''));
+        $ignoreTags = array_merge(['a', 'button', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'figcaption', 'exclude', 'script', 'style', 'svg', 'dfn'], explode(',', \rex_config::get('multiglossar', 'glossar_ignoretags') ?: ''));
         foreach ($ignoreTags as $t) {
             $t = trim($t);
             if (strpos($t, '.') === 0) {
@@ -194,52 +195,73 @@ class Parser
             }
         }
 
-        // Textnode ersetzen
-        if ($node->nodeType === XML_TEXT_NODE) {
-            $originalText = $node->wholeText;
-            $newText = $this->text_replace($originalText);
-
-            if ($originalText !== $newText) {
-                $tmpDom = new \DOMDocument('1.0', 'UTF-8');
-                @$tmpDom->loadHTML('<?xml encoding="UTF-8"><div id="mg-fragment">' . $newText . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-                $container = $tmpDom->getElementsByTagName('div')->item(0);
-
-                if (!$container) {
-                    return;
+        // data-multiglossar-self: Wir rendern hier den Glossar-Eintrag selbst.
+        // Der eigene Begriff (inkl. Alt-Begriffe) wird in diesem Bereich nicht markiert,
+        // andere Glossar-Querverweise bleiben aktiv.
+        $pushedSelfPid = false;
+        if ($node->nodeType === XML_ELEMENT_NODE && $node->hasAttributes()) {
+            $selfAttr = $node->attributes->getNamedItem('data-multiglossar-self');
+            if ($selfAttr) {
+                $selfPid = (int) $selfAttr->nodeValue;
+                if ($selfPid > 0) {
+                    $this->self_pid_stack[] = $selfPid;
+                    $pushedSelfPid = true;
                 }
-
-                $fragment = $this->dom->createDocumentFragment();
-                foreach (iterator_to_array($container->childNodes) as $child) {
-                    $fragment->appendChild($this->dom->importNode($child, true));
-                }
-
-                if (!$fragment->hasChildNodes()) {
-                    return;
-                }
-
-                // Neue Nodes vorbereiten für spätere Rekursion
-                $newNodes = [];
-                foreach ($fragment->childNodes as $n) {
-                    $newNodes[] = $n->cloneNode(true);
-                }
-
-                if ($node->parentNode) {
-                    $node->parentNode->replaceChild($fragment, $node);
-                }
-
-                // Rekursiv weiter in den neu eingefügten Knoten
-                foreach ($newNodes as $newNode) {
-                    $this->parse_childs($newNode);
-                }
-
-                return; // Wichtig: Nicht weiter mit alten Kindern fortfahren
             }
         }
 
-        // Rekursion auf Kindknoten
-        if ($node->hasChildNodes()) {
-            foreach (iterator_to_array($node->childNodes) as $child) {
-                $this->parse_childs($child);
+        try {
+            // Textnode ersetzen
+            if ($node->nodeType === XML_TEXT_NODE) {
+                $originalText = $node->wholeText;
+                $newText = $this->text_replace($originalText);
+
+                if ($originalText !== $newText) {
+                    $tmpDom = new \DOMDocument('1.0', 'UTF-8');
+                    @$tmpDom->loadHTML('<?xml encoding="UTF-8"><div id="mg-fragment">' . $newText . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+                    $container = $tmpDom->getElementsByTagName('div')->item(0);
+
+                    if (!$container) {
+                        return;
+                    }
+
+                    $fragment = $this->dom->createDocumentFragment();
+                    foreach (iterator_to_array($container->childNodes) as $child) {
+                        $fragment->appendChild($this->dom->importNode($child, true));
+                    }
+
+                    if (!$fragment->hasChildNodes()) {
+                        return;
+                    }
+
+                    // Neue Nodes vorbereiten für spätere Rekursion
+                    $newNodes = [];
+                    foreach ($fragment->childNodes as $n) {
+                        $newNodes[] = $n->cloneNode(true);
+                    }
+
+                    if ($node->parentNode) {
+                        $node->parentNode->replaceChild($fragment, $node);
+                    }
+
+                    // Rekursiv weiter in den neu eingefügten Knoten
+                    foreach ($newNodes as $newNode) {
+                        $this->parse_childs($newNode);
+                    }
+
+                    return; // Wichtig: Nicht weiter mit alten Kindern fortfahren
+                }
+            }
+
+            // Rekursion auf Kindknoten
+            if ($node->hasChildNodes()) {
+                foreach (iterator_to_array($node->childNodes) as $child) {
+                    $this->parse_childs($child);
+                }
+            }
+        } finally {
+            if ($pushedSelfPid) {
+                array_pop($this->self_pid_stack);
             }
         }
     }
@@ -261,6 +283,12 @@ class Parser
         foreach ($this->glossar as $i => $gloss_item) {
 
             if (isset($gloss_item['found']) && $gloss_item['found']) {
+                continue;
+            }
+
+            // Innerhalb eines `data-multiglossar-self`-Containers den eigenen Eintrag
+            // (Hauptbegriff + alle Alt-Begriffe) überspringen — Querverweise bleiben aktiv.
+            if ($this->self_pid_stack && in_array((int) $gloss_item['pid'], $this->self_pid_stack, true)) {
                 continue;
             }
 
@@ -327,28 +355,31 @@ class Parser
                 $replacementMap[$replacementToken] = $replace;
                 // '<dfn class="glossarlink" title="' . $gloss_item['definition'] . '" data-toggle="tooltip" rel="tooltip"><a href="' . rex_getUrl($this->glossar_id, '', ['gloss_id' => $gloss_item['pid']]) . '">' . $search_term . '</a></dfn>';
 
-                //                $search = '\b' . $search . '\b([^äüöß])';
-                $search = '\b' . preg_quote($search, '~') . '\b';
+                // Unicode-aware Wortgrenze: Buchstaben, Ziffern, Unterstrich und Bindestrich
+                // gelten als zusammenhängendes "Wort". Damit matcht z.B. "RoS" nicht in "Büros"
+                // (vor `r` steht `ü` ∈ \p{L}) und "E-Mail" matcht nicht in "E-Mail-Adresse".
+                $wordChar = '[\p{L}\p{N}_\-]';
+                $search = '(?<!' . $wordChar . ')' . preg_quote($search, '~') . '(?!' . $wordChar . ')';
 
 
                 if (trim($casesensitive, '|') == '1') {
-                    //                    $regEx = '~(?!((<.*?)))' . $search . '(?!(([^<>]*?)>))~s';
-                    $regEx = '~' . $search . '~s';
+                    $regEx = '~' . $search . '~su';
                 } else {
-                    $regEx = '~' . $search . '~si';
-                    //                    $regEx = '~(?!((<.*?)))' . $search . '(?!(([^<>]*?)>))~si';
+                    $regEx = '~' . $search . '~siu';
                 }
-
-                //                dump($regEx); exit;
 
                 // Wenn der ganze Artikel mit Glossarbegriffen versehen werden soll (Einstellung in Settings article_complete) alle Fundstellen ersetzen
                 $replaceLimit = $replaceAllInCurrentArticle ? -1 : 1;
                 $content = preg_replace_callback($regEx, static function () use ($replacementToken) {
                     return $replacementToken;
                 }, $content, $replaceLimit) ?? $content;
-            }
-            if ($old_content != $content && !$replaceAllInCurrentArticle) {
-                $this->glossar[$i]['found'] = true;
+
+                // Pro Begriffsgruppe nur einen Treffer markieren — wenn Haupt- und Alt-Begriff
+                // direkt nebeneinander stehen ("ABC (Alpha Beta Cell)"), wird nur der erste markiert.
+                if ($old_content !== $content && !$replaceAllInCurrentArticle) {
+                    $this->glossar[$i]['found'] = true;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
- Fix: Buttons werden standardmäßig nicht mehr mit Glossarbegriffen markiert.
- Fix: Wortgrenzen-Erkennung berücksichtigt nun Umlaute und Bindestriche korrekt (Lookarounds mit \p{L}\p{N}_- + u-Modifier). "RoS" matcht damit nicht mehr in "Büros", "E-Mail" matcht nicht mehr in "E-Mail-Adresse".
- Fix: Bei direkter Nachbarschaft von Abkürzung und Langform wird nur noch eine Variante pro Begriffsgruppe markiert (break nach erstem erfolgreichen Marker-Match).
- Feature: data-multiglossar-self="<pid>" am Wrapper eines gerenderten Glossar-Eintrags signalisiert dem Parser, den eigenen Begriff (inkl. Alt-Begriffe) auszunehmen. Querverweise auf andere Glossarbegriffe innerhalb des Eintrags bleiben aktiv. Beispiel-Listenansicht-Modul nutzt das Attribut bereits.